### PR TITLE
Create unconstrained_delegation.py

### DIFF
--- a/nxc/modules/unconstrained_delegation.py
+++ b/nxc/modules/unconstrained_delegation.py
@@ -1,0 +1,55 @@
+from nxc.parsers.ldap_results import parse_result_attributes
+from impacket.dcerpc.v5.samr import UF_TRUSTED_FOR_DELEGATION
+
+class NXCModule:
+    """
+    Module by Bernardo Rodrigues
+    """
+    name = "unconstrained_delegation"
+    description = "Enumerate machines with Unconstrained Delegation (enabled for delegation but lacking services, suggesting a security risk)"
+    supported_protocols = ["ldap"]
+    opsec_safe = True
+    multiple_hosts = True
+
+    def options(self, context, module_options):
+        pass
+
+    def on_login(self, context, connection):
+        context.log.display("Searching for machines with Unconstrained Delegation...")
+
+        search_filter = f"(&(objectCategory=computer)(userAccountControl:1.2.840.113556.1.4.803:={UF_TRUSTED_FOR_DELEGATION})(!(msDS-AllowedToDelegateTo=*))(!(userAccountControl:1.2.840.113556.1.4.803:=8192)))"
+
+        try:
+
+            results_raw = connection.ldap_connection.search(
+                searchBase=connection.baseDN,
+                searchFilter=search_filter,
+                attributes=["sAMAccountName", "dNSHostName"],
+                sizeLimit=0
+            )
+
+
+            results_parsed = parse_result_attributes(results_raw)
+
+            context.log.display(f"Search Finished. {len(results_parsed)} results found and processed.")
+
+
+            found_machines = []
+            for entry in results_parsed:
+
+                sam_account_name = entry.get('sAMAccountName', 'N/A')
+                dns_hostname = entry.get('dNSHostName', 'N/A')
+
+                if sam_account_name != 'N/A':
+                    found_machines.append(f"{sam_account_name} ({dns_hostname})")
+
+
+            if found_machines:
+                context.log.success("Machines with Unconstrained Delegation found:")
+                for machine in found_machines:
+                    context.log.highlight(f"  - {machine}")
+            else:
+                context.log.display("Machines with Unconstrained Delegation not found")
+
+        except Exception as e:
+            context.log.error(f"Error ({type(e).__name__}): {e}")


### PR DESCRIPTION
Finds non-DC machines marked as 'Trusted for Delegation' with no msDS-AllowedToDelegateTo set.

## Description

The module finds computer accounts that are configured for Delegation (with the TRUSTED_FOR_DELEGATION flag enabled) but have no specific services listed in the msDS-AllowedToDelegateTo attribute, creating the Unconstrained Delegation vulnerability.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] This requires a third party update (such as Impacket, Dploot, lsassy, etc)

**Local Testing Environment:**
* **Python Version:** 3.13.3
* **OS:** Kali Linux 2025.2

**Target Environment (during tests):**
* **Domain Controller:** Windows Server 2019 / 2022

**Added Feature/Enhancement Setup:**

Here are the steps to create the specific misconfiguration in an Active Directory lab to test the module:

1. On your Domain Controller, open **"Active Directory Users and Computers"** (`dsa.msc`).
2. Ensure that **"Advanced Features"** is enabled under the **"View"** menu. This is required to see the **"Delegation"** tab on computer objects.
3. Find a target computer account (e.g., `WKSTN01`). Right-click and go to **Properties**.
4. Navigate to the **Delegation** tab.
5. Select the option: **"Trust this computer for delegation to specified services only"**.
6. **Crucially**, do not add any services to the list below. Leave the service list completely empty.
7. Click **Apply** and **OK**.

This computer is now configured for Constrained Delegation without any service constraints and should be flagged by the module.


## Checklist:

- [ ] I have ran Ruff against my changes (via poetry: `poetry run python -m ruff check . --preview`, use `--fix` to automatically fix what it can)
- [ ] I have added or updated the tests/e2e_commands.txt file if necessary
- [ ] New and existing e2e tests pass locally with my changes
- [ ] If reliant on changes of third party dependencies, such as Impacket, dploot, lsassy, etc, I have linked the relevant PRs in those projects
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (PR here: https://github.com/Pennyw0rth/NetExec-Wiki)
